### PR TITLE
Minor refactor

### DIFF
--- a/src/Config/ConfigViewer.cs
+++ b/src/Config/ConfigViewer.cs
@@ -15,18 +15,13 @@ namespace ConfigView.Config
 
         public IEnumerable<ConfigView> Get()
         {
-            return GetContents(_configurationRoot);
-        }
-
-        private IEnumerable<ConfigView> GetContents(IConfigurationRoot root)
-        {
             void RecurseChildren(IList<ConfigView> configs,
                 ConfigView config,
                 IEnumerable<IConfigurationSection> children)
             {
                 foreach (IConfigurationSection child in children)
                 {
-                    var valueAndProvider = GetValueAndProvider(root, child.Path);
+                    var valueAndProvider = GetValueAndProvider(_configurationRoot, child.Path);
                     config = config with { Key = child.Key, Path = child.Path };
                     if (valueAndProvider.Source != null)
                     {
@@ -41,7 +36,7 @@ namespace ConfigView.Config
             List<ConfigView> conigfData = new();
             ConfigView currentConfig = new();
 
-            RecurseChildren(conigfData, currentConfig, root.GetChildren());
+            RecurseChildren(conigfData, currentConfig, _configurationRoot.GetChildren());
 
             return conigfData;
         }

--- a/tests/Fakes/FakeConfiguration.cs
+++ b/tests/Fakes/FakeConfiguration.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
@@ -8,7 +9,7 @@ namespace ConfigView.Tests.Fakes
 {
     public class FakeConfiguration : IConfiguration
     {
-        private IEnumerable<IConfigurationSection> Sections { get; set; }
+        private IEnumerable<IConfigurationSection> Sections { get; set; } = Enumerable.Empty<IConfigurationSection>();
         public IEnumerable<IConfigurationSection> GetChildren() => Sections;
 
         # region Not needed implementations


### PR DESCRIPTION
Creating empty section on property init to avoid nullable warnings and remove method which is unnecessary when getting contents.

All tests passed.